### PR TITLE
Tidying up some of the core OSCAL methods

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,13 +1,3 @@
-# oscalkit - OSCAL conversion utility
-# Written in 2017 by Andrew Weiss <andrew.weiss@docker.com>
-
-# To the extent possible under law, the author(s) have dedicated all copyright
-# and related and neighboring rights to this software to the public domain worldwide.
-# This software is distributed without any warranty.
-
-# You should have received a copy of the CC0 Public Domain Dedication along with this software.
-# If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-
 Makefile
 oscalkit
 README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,3 @@
-# oscalkit - OSCAL conversion utility
-# Written in 2017 by Andrew Weiss <andrew.weiss@docker.com>
-
-# To the extent possible under law, the author(s) have dedicated all copyright
-# and related and neighboring rights to this software to the public domain worldwide.
-# This software is distributed without any warranty.
-
-# You should have received a copy of the CC0 Public Domain Dedication along with this software.
-# If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-
 FROM golang:1.11-alpine AS builder
 WORKDIR /go/src/github.com/docker/oscalkit
 ARG VERSION

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,13 +1,3 @@
-# oscalkit - OSCAL conversion utility
-# Written in 2017 by Andrew Weiss <andrew.weiss@docker.com>
-
-# To the extent possible under law, the author(s) have dedicated all copyright
-# and related and neighboring rights to this software to the public domain worldwide.
-# This software is distributed without any warranty.
-
-# You should have received a copy of the CC0 Public Domain Dedication along with this software.
-# If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-
 FROM golang:1.11 AS race-detector
 WORKDIR /go/src/github.com/docker/oscalkit
 COPY . .

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,3 @@
-# oscalkit - OSCAL conversion utility
-# Written in 2017 by Andrew Weiss <andrew.weiss@docker.com>
-
-# To the extent possible under law, the author(s) have dedicated all copyright
-# and related and neighboring rights to this software to the public domain worldwide.
-# This software is distributed without any warranty.
-
-# You should have received a copy of the CC0 Public Domain Dedication along with this software.
-# If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-
 GOOS := darwin
 GOARCH := amd64
 VERSION := 0.2.0

--- a/cli/cmd/cmd.go
+++ b/cli/cmd/cmd.go
@@ -1,13 +1,3 @@
-// oscalkit - OSCAL conversion utility
-// Written in 2017 by Andrew Weiss <andrew.weiss@docker.com>
-
-// To the extent possible under law, the author(s) have dedicated all copyright
-// and related and neighboring rights to this software to the public domain worldwide.
-// This software is distributed without any warranty.
-
-// You should have received a copy of the CC0 Public Domain Dedication along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-
 package cmd
 
 import (

--- a/cli/cmd/convert/convert.go
+++ b/cli/cmd/convert/convert.go
@@ -1,13 +1,3 @@
-// oscalkit - OSCAL conversion utility
-// Written in 2017 by Andrew Weiss <andrew.weiss@docker.com>
-
-// To the extent possible under law, the author(s) have dedicated all copyright
-// and related and neighboring rights to this software to the public domain worldwide.
-// This software is distributed without any warranty.
-
-// You should have received a copy of the CC0 Public Domain Dedication along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-
 package convert
 
 import (

--- a/cli/cmd/convert/opencontrol.go
+++ b/cli/cmd/convert/opencontrol.go
@@ -1,13 +1,3 @@
-// oscalkit - OSCAL conversion utility
-// Written in 2017 by Andrew Weiss <andrew.weiss@docker.com>
-
-// To the extent possible under law, the author(s) have dedicated all copyright
-// and related and neighboring rights to this software to the public domain worldwide.
-// This software is distributed without any warranty.
-
-// You should have received a copy of the CC0 Public Domain Dedication along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-
 package convert
 
 var includeXML bool

--- a/cli/cmd/convert/opencontrol.go
+++ b/cli/cmd/convert/opencontrol.go
@@ -48,7 +48,7 @@ var includeXML bool
 // 		}
 
 // 		if includeXML {
-// 			rawXMLOCOSCAL, err := ocOSCAL.RawXML(true)
+// 			rawXMLOCOSCAL, err := ocOSCAL.XML(true)
 // 			if err != nil {
 // 				return cli.NewExitError(fmt.Sprintf("Error producing raw XML: %s", err), 1)
 // 			}
@@ -58,7 +58,7 @@ var includeXML bool
 // 		}
 
 // 		if yaml {
-// 			rawYAMLOCOSCAL, err := ocOSCAL.RawYAML()
+// 			rawYAMLOCOSCAL, err := ocOSCAL.YAML()
 // 			if err != nil {
 // 				return cli.NewExitError(err, 1)
 // 			}
@@ -67,7 +67,7 @@ var includeXML bool
 // 			}
 // 		}
 
-// 		rawOCOSCAL, err := ocOSCAL.RawJSON(true)
+// 		rawOCOSCAL, err := ocOSCAL.JSON(true)
 // 		if err != nil {
 // 			return cli.NewExitError(err, 1)
 // 		}

--- a/cli/cmd/convert/oscal.go
+++ b/cli/cmd/convert/oscal.go
@@ -176,7 +176,7 @@ func convert(src io.Reader, dest io.Writer, outputFormat string) error {
 			return err
 		}
 
-		oscalJSON, err := oscal.RawJSON(true)
+		oscalJSON, err := oscal.JSON(true)
 		if err != nil {
 			return err
 		}
@@ -197,7 +197,7 @@ func convert(src io.Reader, dest io.Writer, outputFormat string) error {
 			return err
 		}
 
-		oscalXML, err := oscal.RawXML(true)
+		oscalXML, err := oscal.XML(true)
 		if err != nil {
 			return err
 		}
@@ -218,7 +218,7 @@ func convert(src io.Reader, dest io.Writer, outputFormat string) error {
 			return err
 		}
 
-		oscalYAML, err := oscal.RawYAML()
+		oscalYAML, err := oscal.YAML()
 		if err != nil {
 			return err
 		}

--- a/cli/cmd/convert/oscal.go
+++ b/cli/cmd/convert/oscal.go
@@ -1,13 +1,3 @@
-// oscalkit - OSCAL conversion utility
-// Written in 2017 by Andrew Weiss <andrew.weiss@docker.com>
-
-// To the extent possible under law, the author(s) have dedicated all copyright
-// and related and neighboring rights to this software to the public domain worldwide.
-// This software is distributed without any warranty.
-
-// You should have received a copy of the CC0 Public Domain Dedication along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-
 package convert
 
 import (
@@ -171,17 +161,12 @@ func convert(src io.Reader, dest io.Writer, outputFormat string) error {
 	case "json":
 		logrus.Debug("Converting to JSON")
 
-		oscal, err := oscal.New(src)
+		o, err := oscal.New(src)
 		if err != nil {
 			return err
 		}
 
-		oscalJSON, err := oscal.JSON(true)
-		if err != nil {
-			return err
-		}
-
-		if _, err := dest.Write(oscalJSON); err != nil {
+		if err := o.JSON(dest, true); err != nil {
 			return err
 		}
 
@@ -192,17 +177,12 @@ func convert(src io.Reader, dest io.Writer, outputFormat string) error {
 	case "xml":
 		logrus.Debug("Converting to XML")
 
-		oscal, err := oscal.New(src)
+		o, err := oscal.New(src)
 		if err != nil {
 			return err
 		}
 
-		oscalXML, err := oscal.XML(true)
-		if err != nil {
-			return err
-		}
-
-		if _, err := dest.Write(oscalXML); err != nil {
+		if err := o.XML(dest, true); err != nil {
 			return err
 		}
 
@@ -213,17 +193,12 @@ func convert(src io.Reader, dest io.Writer, outputFormat string) error {
 	case "yaml":
 		logrus.Debug("Converting to YAML")
 
-		oscal, err := oscal.New(src)
+		o, err := oscal.New(src)
 		if err != nil {
 			return err
 		}
 
-		oscalYAML, err := oscal.YAML()
-		if err != nil {
-			return err
-		}
-
-		if _, err := dest.Write(oscalYAML); err != nil {
+		if err := o.YAML(dest); err != nil {
 			return err
 		}
 

--- a/cli/cmd/validate.go
+++ b/cli/cmd/validate.go
@@ -1,13 +1,3 @@
-// oscalkit - OSCAL conversion utility
-// Written in 2017 by Andrew Weiss <andrew.weiss@docker.com>
-
-// To the extent possible under law, the author(s) have dedicated all copyright
-// and related and neighboring rights to this software to the public domain worldwide.
-// This software is distributed without any warranty.
-
-// You should have received a copy of the CC0 Public Domain Dedication along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-
 package cmd
 
 import (

--- a/cli/main.go
+++ b/cli/main.go
@@ -1,13 +1,3 @@
-// oscalkit - OSCAL conversion utility
-// Written in 2017 by Andrew Weiss <andrew.weiss@docker.com>
-
-// To the extent possible under law, the author(s) have dedicated all copyright
-// and related and neighboring rights to this software to the public domain worldwide.
-// This software is distributed without any warranty.
-
-// You should have received a copy of the CC0 Public Domain Dedication along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-
 package main
 
 import (

--- a/types/oscal/catalog/href.go
+++ b/types/oscal/catalog/href.go
@@ -34,7 +34,11 @@ func (h *Href) UnmarshalJSON(b []byte) error {
 }
 
 func (h *Href) MarshalJSON() ([]byte, error) {
-	return json.Marshal(h.String())
+	if h.URL != nil {
+		return json.Marshal(h.String())
+	}
+
+	return json.Marshal("")
 }
 
 func (h *Href) MarshalXMLAttr(name xml.Name) (xml.Attr, error) {

--- a/types/oscal/catalog/prose.go
+++ b/types/oscal/catalog/prose.go
@@ -1,13 +1,3 @@
-// oscalkit - OSCAL conversion utility
-// Written in 2017 by Andrew Weiss <andrew.weiss@docker.com>
-
-// To the extent possible under law, the author(s) have dedicated all copyright
-// and related and neighboring rights to this software to the public domain worldwide.
-// This software is distributed without any warranty.
-
-// You should have received a copy of the CC0 Public Domain Dedication along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-
 package catalog
 
 import (

--- a/types/oscal/oscal.go
+++ b/types/oscal/oscal.go
@@ -196,5 +196,5 @@ func (o *OSCAL) encode(options encodeOptions) error {
 		return yaml.NewEncoder(options.writer).Encode(o)
 	}
 
-	return errors.New("Incorret format specified")
+	return errors.New("Incorrect format specified")
 }

--- a/types/oscal/oscal.go
+++ b/types/oscal/oscal.go
@@ -190,23 +190,23 @@ func New(r io.Reader) (*OSCAL, error) {
 	return nil, errors.New("Malformed OSCAL. Must be XML or JSON")
 }
 
-// RawXML ...
-func (o *OSCAL) RawXML(prettify bool) ([]byte, error) {
+// XML returns a byte slice containing the raw XML from the OSCAL object
+func (o *OSCAL) XML(prettify bool) ([]byte, error) {
 	if prettify {
 		return xml.MarshalIndent(o, "", "  ")
 	}
 	return xml.Marshal(o)
 }
 
-// RawJSON ...
-func (o *OSCAL) RawJSON(prettify bool) ([]byte, error) {
+// JSON returns a byte slice containing the raw JSON from the OSCAL object
+func (o *OSCAL) JSON(prettify bool) ([]byte, error) {
 	if prettify {
 		return json.MarshalIndent(o, "", "  ")
 	}
 	return json.Marshal(o)
 }
 
-// RawYAML ...
-func (o *OSCAL) RawYAML() ([]byte, error) {
+// YAML returns a byte slice containing the raw YAML from the OSCAL object
+func (o *OSCAL) YAML() ([]byte, error) {
 	return yaml.Marshal(o)
 }

--- a/types/oscal/oscal.go
+++ b/types/oscal/oscal.go
@@ -155,27 +155,46 @@ func New(r io.Reader) (*OSCAL, error) {
 
 // XML writes the OSCAL object as XML to the given writer
 func (o *OSCAL) XML(w io.Writer, prettify bool) error {
-	e := xml.NewEncoder(w)
-	if prettify {
-		e.Indent("", "  ")
-		return e.Encode(o)
-	}
-
-	return e.Encode(o)
+	return o.encode(encodeOptions{"xml", prettify, w})
 }
 
 // JSON writes the OSCAL object as JSON to the given writer
 func (o *OSCAL) JSON(w io.Writer, prettify bool) error {
-	e := json.NewEncoder(w)
-	if prettify {
-		e.SetIndent("", "  ")
-		return e.Encode(o)
-	}
-
-	return e.Encode(o)
+	return o.encode(encodeOptions{"json", prettify, w})
 }
 
 // YAML writes the OSCAL object as YAML to the given writer
 func (o *OSCAL) YAML(w io.Writer) error {
-	return yaml.NewEncoder(w).Encode(o)
+	return o.encode(encodeOptions{format: "yaml", writer: w})
+}
+
+type encodeOptions struct {
+	format   string
+	prettify bool
+	writer   io.Writer
+}
+
+func (o *OSCAL) encode(options encodeOptions) error {
+	switch options.format {
+	case "xml":
+		e := xml.NewEncoder(options.writer)
+		if options.prettify {
+			e.Indent("", "  ")
+		}
+
+		return e.Encode(o)
+
+	case "json":
+		e := json.NewEncoder(options.writer)
+		if options.prettify {
+			e.SetIndent("", "  ")
+		}
+
+		return e.Encode(o)
+
+	case "yaml":
+		return yaml.NewEncoder(options.writer).Encode(o)
+	}
+
+	return errors.New("Incorret format specified")
 }

--- a/types/oscal/oscal.go
+++ b/types/oscal/oscal.go
@@ -1,13 +1,3 @@
-// oscalkit - OSCAL conversion utility
-// Written in 2017 by Andrew Weiss <andrew.weiss@docker.com>
-
-// To the extent possible under law, the author(s) have dedicated all copyright
-// and related and neighboring rights to this software to the public domain worldwide.
-// This software is distributed without any warranty.
-
-// You should have received a copy of the CC0 Public Domain Dedication along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-
 package oscal
 
 import (
@@ -23,7 +13,7 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
-// OSCAL ...
+// OSCAL contains specific OSCAL components
 type OSCAL struct {
 	XMLName xml.Name         `json:"-" yaml:"-"`
 	Catalog *catalog.Catalog `json:"catalog,omitempty" yaml:"catalog,omitempty"`
@@ -31,7 +21,7 @@ type OSCAL struct {
 	Profile *profile.Profile `json:"profile,omitempty" yaml:"profile,omitempty"`
 }
 
-// MarshalXML ...
+// MarshalXML marshals either a catalog or a profile
 func (o *OSCAL) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	if o.Catalog != nil {
 		o.XMLName = o.Catalog.XMLName
@@ -48,16 +38,11 @@ func (o *OSCAL) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	return nil
 }
 
-// Options ...
-type Options struct {
-	Reader io.Reader
-}
-
 // dockerOptions ...
-type dockerOptions struct {
-	dockerYAMLFilepath string
-	dockersDir         string
-}
+// type dockerOptions struct {
+// 	dockerYAMLFilepath string
+// 	dockersDir         string
+// }
 
 // NewFromOC initializes an OSCAL type from raw docker data
 // func NewFromOC(options dockerOptions) (*OSCAL, error) {
@@ -111,16 +96,14 @@ type dockerOptions struct {
 // 	return convertOC(oc, ocComponents)
 // }
 
-// New ...
+// New returns a concrete OSCAL type from a reader
 func New(r io.Reader) (*OSCAL, error) {
-	var err error
-
-	rawOSCAL, err := ioutil.ReadAll(r)
+	oscalBytes, err := ioutil.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}
 
-	d := xml.NewDecoder(bytes.NewReader(rawOSCAL))
+	d := xml.NewDecoder(bytes.NewReader(oscalBytes))
 	for {
 		token, err := d.Token()
 		if err != nil || token == nil {
@@ -131,34 +114,23 @@ func New(r io.Reader) (*OSCAL, error) {
 			switch startElement.Name.Local {
 			case "catalog":
 				var catalog catalog.Catalog
-				if err := xml.Unmarshal(rawOSCAL, &catalog); err != nil {
+				if err := d.DecodeElement(&catalog, &startElement); err != nil {
 					return nil, err
 				}
 				return &OSCAL{Catalog: &catalog}, nil
 
-			// case "declarations":
-			// 	var declarations Declarations
-			// 	if err := xml.Unmarshal(rawOSCAL, &declarations); err != nil {
-			// 		return nil, err
-			// 	}
-			// 	return &OSCAL{Declarations: &declarations}, nil
-
 			case "profile":
 				var profile profile.Profile
-				if err := xml.Unmarshal(rawOSCAL, &profile); err != nil {
+				if err := d.DecodeElement(&profile, &startElement); err != nil {
 					return nil, err
 				}
 				return &OSCAL{Profile: &profile}, nil
 			}
-
 		}
 	}
 
 	var oscalT map[string]json.RawMessage
-	if err := json.Unmarshal(rawOSCAL, &oscalT); err != nil {
-		return nil, err
-	}
-	if err = json.Unmarshal(rawOSCAL, &oscalT); err == nil {
+	if err := json.Unmarshal(oscalBytes, &oscalT); err == nil {
 		for k, v := range oscalT {
 			switch k {
 			case "catalog":
@@ -168,13 +140,6 @@ func New(r io.Reader) (*OSCAL, error) {
 				}
 				return &OSCAL{Catalog: &catalog}, nil
 
-			// case "declarations":
-			// 	var declarations Declarations
-			// 	if err := json.Unmarshal(v, &declarations); err != nil {
-			// 		return nil, err
-			// 	}
-			// 	return &OSCAL{Declarations: &declarations}, nil
-
 			case "profile":
 				var profile profile.Profile
 				if err := json.Unmarshal(v, &profile); err != nil {
@@ -183,30 +148,34 @@ func New(r io.Reader) (*OSCAL, error) {
 				return &OSCAL{Profile: &profile}, nil
 			}
 		}
-
-		return nil, errors.New("Malformed OSCAL")
 	}
 
 	return nil, errors.New("Malformed OSCAL. Must be XML or JSON")
 }
 
-// XML returns a byte slice containing the raw XML from the OSCAL object
-func (o *OSCAL) XML(prettify bool) ([]byte, error) {
+// XML writes the OSCAL object as XML to the given writer
+func (o *OSCAL) XML(w io.Writer, prettify bool) error {
+	e := xml.NewEncoder(w)
 	if prettify {
-		return xml.MarshalIndent(o, "", "  ")
+		e.Indent("", "  ")
+		return e.Encode(o)
 	}
-	return xml.Marshal(o)
+
+	return e.Encode(o)
 }
 
-// JSON returns a byte slice containing the raw JSON from the OSCAL object
-func (o *OSCAL) JSON(prettify bool) ([]byte, error) {
+// JSON writes the OSCAL object as JSON to the given writer
+func (o *OSCAL) JSON(w io.Writer, prettify bool) error {
+	e := json.NewEncoder(w)
 	if prettify {
-		return json.MarshalIndent(o, "", "  ")
+		e.SetIndent("", "  ")
+		return e.Encode(o)
 	}
-	return json.Marshal(o)
+
+	return e.Encode(o)
 }
 
-// YAML returns a byte slice containing the raw YAML from the OSCAL object
-func (o *OSCAL) YAML() ([]byte, error) {
-	return yaml.Marshal(o)
+// YAML writes the OSCAL object as YAML to the given writer
+func (o *OSCAL) YAML(w io.Writer) error {
+	return yaml.NewEncoder(w).Encode(o)
 }

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -1,13 +1,3 @@
-// oscalkit - OSCAL conversion utility
-// Written in 2017 by Andrew Weiss <andrew.weiss@docker.com>
-
-// To the extent possible under law, the author(s) have dedicated all copyright
-// and related and neighboring rights to this software to the public domain worldwide.
-// This software is distributed without any warranty.
-
-// You should have received a copy of the CC0 Public Domain Dedication along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-
 package validator
 
 import (

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -1,13 +1,3 @@
-// oscalkit - OSCAL conversion utility
-// Written in 2017 by Andrew Weiss <andrew.weiss@docker.com>
-
-// To the extent possible under law, the author(s) have dedicated all copyright
-// and related and neighboring rights to this software to the public domain worldwide.
-// This software is distributed without any warranty.
-
-// You should have received a copy of the CC0 Public Domain Dedication along with this software.
-// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
-
 package validator
 
 import (


### PR DESCRIPTION
Tidying up some of the core OSCAL methods. Accept `io.Writer` as appropriate. Removed CC0 Public Domain header from all source code files in favor of blanket `LICENSE` file at the root.