### PR TITLE
Fix set param id attribute

### DIFF
--- a/metaschema/types.tmpl
+++ b/metaschema/types.tmpl
@@ -16,14 +16,18 @@ type {{toCamel .Name}} struct {
   {{- if eq "profile" .Name}}
   ID string `xml:"id,attr,omitempty" json:"id,omitempty"`
   {{- end}}
-  {{- range .Flags}}
+{{- range .Flags}}
   {{- $cf := commentFlag .Name $m.DefineFlag}}
   {{- range $cf}}
   // {{ . }}
   {{- end}}
   {{- $dt := parseDatatype .Datatype $packageName}}
+  {{- if and (eq "id" .Name) (eq "profile" $packageName)}}
+  Id string `xml:"param-id,attr,omitempty" json:"id,omitempty"`
+  {{- else}}
   {{toCamel .Name}} {{if eq "" $dt}}string{{else}}{{$dt}}{{end}} `xml:"{{ .Name }},attr,omitempty" json:"{{toLowerCamel .Name}},omitempty"`
   {{- end}}
+{{- end}}
 
   {{- range .Model.Field}}
   {{toCamel .Named}} {{if requiresPointer .Named $m}}*{{end}}{{packageImport .Named $m}}{{toCamel .Named}} `xml:"{{ .Named }},omitempty" json:"{{toLowerCamel .Named}},omitempty"`

--- a/types/oscal/profile/profile.go
+++ b/types/oscal/profile/profile.go
@@ -68,7 +68,7 @@ type Exclude struct {
 
 // A parameter setting, to be propagated to points of insertion
 type SetParam struct {
-	Id           string               `xml:"id,attr,omitempty" json:"id,omitempty"`
+	Id           string               `xml:"param-id,attr,omitempty" json:"id,omitempty"`
 	Class        string               `xml:"class,attr,omitempty" json:"class,omitempty"`
 	DependsOn    string               `xml:"depends-on,attr,omitempty" json:"dependsOn,omitempty"`
 	Label        catalog.Label        `xml:"label,omitempty" json:"label,omitempty"`


### PR DESCRIPTION
This PR addresses the discrepancy  for `SetParam` struct: ID got reverted back to `id` instead of `param-id` in https://github.com/docker/oscalkit/pull/40