### PR TITLE
remove possibleValues from controlImplementation[]

### DIFF
--- a/templates/implementation.go
+++ b/templates/implementation.go
@@ -51,7 +51,6 @@ var ImplementationGenerated = implementation.Implementation{
 												Guidance: "{{.Guidance}}",
 												ParameterID: "{{.ParameterID}}",
 												ValueID: "{{.ValueID}}",
-												DefaultValue: "{{.PossibleValues}}",
 												PossibleValues: []string{
 													{{range .PossibleValues}}
 														"{{.}}",
@@ -106,11 +105,6 @@ var ImplementationGenerated = implementation.Implementation{
 												ParameterID: "{{.ParameterID}}",
 												ValueID: "{{.ValueID}}",
 												DefaultValue: "{{.DefaultValue}}",
-												PossibleValues: []string{
-													{{range .PossibleValues}}
-														"{{.}}",
-													{{end}}
-												},
 											},
 											{{end}}
 										},


### PR DESCRIPTION
- remove possibleValues from `controlImplementation[].paramters[]`
- remove defaultValues from `implementsProfiles[].parameters[]`

This change is made in favor of the oscal implementation "ComponentDefinition" as was suggested by @anweiss

As per the [prototype](https://gist.github.com/anweiss/8afd321b6bf2a9d4e1679657a1b8f2fe), the chain  `implementsProfiles[_].controlConfigurations[_].parameters[_]` does not contain `defaultValues` and the chain  `controlImplementations[_].controlConfigurations[_].parameters[_]` does not contain `possibleValues`. Hence removed.