### PR TITLE
Add modify-add feature

### DIFF
--- a/generator/generator_test.go
+++ b/generator/generator_test.go
@@ -6,6 +6,8 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/davecgh/go-spew/spew"
+
 	"github.com/docker/oscalkit/types/oscal/catalog"
 	"github.com/docker/oscalkit/types/oscal/profile"
 )
@@ -215,4 +217,68 @@ func failTest(err error, t *testing.T) {
 	if err != nil {
 		t.Error(t)
 	}
+}
+
+func TestAddPartInCatalog(t *testing.T) {
+
+	alt := []profile.Alter{
+		profile.Alter{
+			ControlId: "ac-10",
+			Additions: []profile.Add{
+				profile.Add{
+					Parts: []catalog.Part{
+						catalog.Part{
+							Id:    "ac-10_prm",
+							Class: "guidance",
+							Title: "parent prm guidance",
+						},
+						catalog.Part{
+							Id:    "ac-2_prm3",
+							Class: "whatever",
+						},
+					},
+				},
+			},
+		},
+		profile.Alter{
+			SubcontrolId: "ac-10.1",
+			Additions: []profile.Add{
+				profile.Add{
+					Parts: []catalog.Part{
+						catalog.Part{
+							Id:    "ac-10_obj",
+							Class: "yolo",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	cat := catalog.Catalog{
+		Groups: []catalog.Group{
+			catalog.Group{
+				Controls: []catalog.Control{
+					catalog.Control{
+						Id: "ac-10",
+						Subcontrols: []catalog.Subcontrol{
+							catalog.Subcontrol{
+								Id:    "ac-10.1",
+								Parts: []catalog.Part{},
+							},
+						},
+						Parts: []catalog.Part{
+							catalog.Part{
+								Id:    "ac_10_prm",
+								Class: "guidance",
+								Title: "sdfsdfsd",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	spew.Dump(AddPartInCatalog(alt, &cat))
 }

--- a/generator/generator_test.go
+++ b/generator/generator_test.go
@@ -6,8 +6,6 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/davecgh/go-spew/spew"
-
 	"github.com/docker/oscalkit/types/oscal/catalog"
 	"github.com/docker/oscalkit/types/oscal/profile"
 )
@@ -121,6 +119,20 @@ func TestCreateCatalogsFromProfile(t *testing.T) {
 				},
 			},
 		},
+		Modify: &profile.Modify{
+			Alterations: []profile.Alter{
+				profile.Alter{
+					ControlId: "ac-1",
+					Additions: []profile.Add{profile.Add{
+						Parts: []catalog.Part{
+							catalog.Part{
+								Id: "ac-1_obj",
+							},
+						},
+					}},
+				},
+			},
+		},
 	}
 	x, err := CreateCatalogsFromProfile(&p)
 	if err != nil {
@@ -155,8 +167,8 @@ func TestCreateCatalogsFromProfileWithBadHref(t *testing.T) {
 		},
 	}
 	catalogs, err := CreateCatalogsFromProfile(&p)
-	if err != nil {
-		t.Error("error should  be nil")
+	if err == nil {
+		t.Error("error should not be nil")
 	}
 	if len(catalogs) > 0 {
 		t.Error("nothing should be parsed due to bad url")
@@ -192,6 +204,50 @@ func TestSubControlsMapping(t *testing.T) {
 				},
 			},
 		},
+		Modify: &profile.Modify{
+			Alterations: []profile.Alter{
+				profile.Alter{
+					ControlId: "ac-1",
+					Additions: []profile.Add{profile.Add{
+						Parts: []catalog.Part{
+							catalog.Part{
+								Id: "ac-1_obj",
+							},
+						},
+					}},
+				},
+				profile.Alter{
+					ControlId: "ac-2",
+					Additions: []profile.Add{profile.Add{
+						Parts: []catalog.Part{
+							catalog.Part{
+								Id: "ac-2_obj",
+							},
+						},
+					}},
+				},
+				profile.Alter{
+					SubcontrolId: "ac-2.1",
+					Additions: []profile.Add{profile.Add{
+						Parts: []catalog.Part{
+							catalog.Part{
+								Id: "ac-2.1_obj",
+							},
+						},
+					}},
+				},
+				profile.Alter{
+					SubcontrolId: "ac-2.2",
+					Additions: []profile.Add{profile.Add{
+						Parts: []catalog.Part{
+							catalog.Part{
+								Id: "ac-2.2_obj",
+							},
+						},
+					}},
+				},
+			},
+		},
 	}
 
 	c, err := CreateCatalogsFromProfile(&profile)
@@ -213,28 +269,18 @@ func TestGetCatalogInvalidFilePath(t *testing.T) {
 	}
 }
 
-func failTest(err error, t *testing.T) {
-	if err != nil {
-		t.Error(t)
-	}
-}
-
-func TestAddPartInCatalog(t *testing.T) {
-
-	alt := []profile.Alter{
-		profile.Alter{
+func TestProcessAdditionWithSameClass(t *testing.T) {
+	partID := "ac-10_prt"
+	class := "guidance"
+	alters := []profile.Alter{
+		{
 			ControlId: "ac-10",
 			Additions: []profile.Add{
 				profile.Add{
 					Parts: []catalog.Part{
 						catalog.Part{
-							Id:    "ac-10_prm",
-							Class: "guidance",
-							Title: "parent prm guidance",
-						},
-						catalog.Part{
-							Id:    "ac-2_prm3",
-							Class: "whatever",
+							Id:    partID,
+							Class: class,
 						},
 					},
 				},
@@ -246,32 +292,35 @@ func TestAddPartInCatalog(t *testing.T) {
 				profile.Add{
 					Parts: []catalog.Part{
 						catalog.Part{
-							Id:    "ac-10_obj",
-							Class: "yolo",
+							Id:    partID,
+							Class: class,
 						},
 					},
 				},
 			},
 		},
 	}
-
-	cat := catalog.Catalog{
+	c := catalog.Catalog{
 		Groups: []catalog.Group{
 			catalog.Group{
 				Controls: []catalog.Control{
 					catalog.Control{
 						Id: "ac-10",
-						Subcontrols: []catalog.Subcontrol{
-							catalog.Subcontrol{
-								Id:    "ac-10.1",
-								Parts: []catalog.Part{},
-							},
-						},
 						Parts: []catalog.Part{
 							catalog.Part{
-								Id:    "ac_10_prm",
-								Class: "guidance",
-								Title: "sdfsdfsd",
+								Id:    partID,
+								Class: class,
+							},
+						},
+						Subcontrols: []catalog.Subcontrol{
+							catalog.Subcontrol{
+								Id: "ac-10.1",
+								Parts: []catalog.Part{
+									catalog.Part{
+										Id:    partID,
+										Class: class,
+									},
+								},
 							},
 						},
 					},
@@ -280,5 +329,100 @@ func TestAddPartInCatalog(t *testing.T) {
 		},
 	}
 
-	spew.Dump(AddPartInCatalog(alt, &cat))
+	o := ProcessAlteration(alters, &c)
+	for _, g := range o.Groups {
+		for _, c := range g.Controls {
+			for i := range c.Parts {
+				expected := fmt.Sprintf("%s_%d", partID, i+1)
+				if c.Parts[i].Id != expected {
+					t.Errorf("%s and %s are not identical", c.Parts[i].Id, expected)
+					return
+				}
+			}
+			for i, sc := range c.Subcontrols {
+				expected := fmt.Sprintf("%s_%d", partID, i+1)
+				if sc.Parts[i].Id != expected {
+					t.Errorf("%s and %s are not identical", sc.Parts[i].Id, expected)
+					return
+				}
+			}
+		}
+	}
+}
+
+func TestProcessAdditionWithDifferentPartClass(t *testing.T) {
+
+	ctrlID := "ac-10"
+	subctrlID := "ac-10.1"
+	partID := "ac-10_stmt.a"
+
+	alters := []profile.Alter{
+		profile.Alter{
+			ControlId: ctrlID,
+			Additions: []profile.Add{
+				profile.Add{
+					Parts: []catalog.Part{
+						catalog.Part{
+							Id:    partID,
+							Class: "c1",
+						},
+					},
+				},
+			},
+		},
+		profile.Alter{
+			SubcontrolId: subctrlID,
+			Additions: []profile.Add{
+				profile.Add{
+					Parts: []catalog.Part{
+						catalog.Part{
+							Id:    partID,
+							Class: "c2",
+						},
+					},
+				},
+			},
+		},
+	}
+	c := catalog.Catalog{
+		Groups: []catalog.Group{
+			catalog.Group{
+				Controls: []catalog.Control{
+					catalog.Control{
+						Id: ctrlID,
+						Parts: []catalog.Part{
+							catalog.Part{
+								Id:    partID,
+								Class: "c3",
+							},
+						},
+						Subcontrols: []catalog.Subcontrol{
+							catalog.Subcontrol{
+								Id: subctrlID,
+								Parts: []catalog.Part{
+									catalog.Part{
+										Id:    partID,
+										Class: "c4",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	o := ProcessAlteration(alters, &c)
+	if len(o.Groups[0].Controls[0].Parts) != 2 {
+		t.Error("parts for controls not getting added properly")
+	}
+	if len(o.Groups[0].Controls[0].Subcontrols[0].Parts) != 2 {
+		t.Error("parts for sub-controls not getting added properly")
+	}
+
+}
+func failTest(err error, t *testing.T) {
+	if err != nil {
+		t.Error(err)
+	}
 }

--- a/generator/manipulation.go
+++ b/generator/manipulation.go
@@ -1,65 +1,178 @@
 package generator
 
 import (
+	"context"
 	"fmt"
+	"os"
+	"time"
 
+	"github.com/sirupsen/logrus"
+
+	"github.com/docker/oscalkit/types/oscal"
 	"github.com/docker/oscalkit/types/oscal/catalog"
 	"github.com/docker/oscalkit/types/oscal/profile"
 )
 
-func AddPartInCatalog(alterations []profile.Alter, c *catalog.Catalog) *catalog.Catalog {
-	for _, x := range alterations {
-		for i, g := range c.Groups {
-			for j, ctrl := range g.Controls {
-				if ctrl.Id == x.ControlId {
-					ctrlIncrement := 1
-					for _, add := range x.Additions {
-						for _, p := range add.Parts {
-							appended := false
-							for catalogCtrlPartIndex, catalogPart := range ctrl.Parts {
-								if p.Class == catalogPart.Class {
-									appended = true
-									ctrl.Parts[catalogCtrlPartIndex].Id = p.Id + fmt.Sprintf("_%d", ctrlIncrement)
-									ctrlIncrement++
-									p.Id = p.Id + fmt.Sprintf("_%d", ctrlIncrement)
-									position := (ctrlIncrement + catalogCtrlPartIndex) - 1
-									ctrl.Parts = append(ctrl.Parts[:position], append([]catalog.Part{p}, ctrl.Parts[position:]...)...)
-								}
-							}
-							if !appended {
-								ctrl.Parts = append(ctrl.Parts, p)
-							}
+//ProcessAddition processess additions of a profile
+func ProcessAddition(alt profile.Alter, controls []catalog.Control) []catalog.Control {
+	for j, ctrl := range controls {
+		if ctrl.Id == alt.ControlId {
+			for _, add := range alt.Additions {
+				for _, p := range add.Parts {
+					appended := false
+					for _, catalogPart := range ctrl.Parts {
+						if p.Class == catalogPart.Class {
+							appended = true
+							//append with all the parts with matching classes
+							parts := ModifyParts(p, ctrl.Parts)
+							ctrl.Parts = parts
 						}
 					}
-					c.Groups[i].Controls[j] = ctrl
+					if !appended {
+						ctrl.Parts = append(ctrl.Parts, p)
+					}
 				}
-				for k, subctrl := range c.Groups[i].Controls[j].Subcontrols {
-					subCtrlIncrement := 1
-					if subctrl.Id == x.SubcontrolId {
-						for _, add := range x.Additions {
-							for _, p := range add.Parts {
-								appended := false
-								for catalogSubCtrlPartIndex, catalogPart := range subctrl.Parts {
-									if p.Class == catalogPart.Class {
-										appended = true
-										subctrl.Parts[catalogSubCtrlPartIndex].Id = p.Id + fmt.Sprintf("_%d", subCtrlIncrement)
-										subCtrlIncrement++
-										position := (subCtrlIncrement + catalogSubCtrlPartIndex) - 1
-										subctrl.Parts = append(subctrl.Parts[:position], append([]catalog.Part{p}, subctrl.Parts[:position]...)...)
-									}
-								}
-								if !appended {
-									subctrl.Parts = append(subctrl.Parts, p)
-								}
+			}
+			controls[j] = ctrl
+		}
+		for k, subctrl := range controls[j].Subcontrols {
+			if subctrl.Id == alt.SubcontrolId {
+				for _, add := range alt.Additions {
+					for _, p := range add.Parts {
+						appended := false
+						for _, catalogPart := range subctrl.Parts {
+							if p.Class == catalogPart.Class {
+								appended = true
+								//append with all the parts
+								parts := ModifyParts(p, subctrl.Parts)
+								subctrl.Parts = parts
 							}
-
+						}
+						if !appended {
+							subctrl.Parts = append(subctrl.Parts, p)
 						}
 					}
-					c.Groups[i].Controls[j].Subcontrols[k] = subctrl
 
 				}
 			}
+			controls[j].Subcontrols[k] = subctrl
+		}
+	}
+	return controls
+}
+
+//ProcessAlteration processess alteration section of a profile
+func ProcessAlteration(alterations []profile.Alter, c *catalog.Catalog) *catalog.Catalog {
+	for _, alt := range alterations {
+		for i, g := range c.Groups {
+			c.Groups[i].Controls = ProcessAddition(alt, g.Controls)
 		}
 	}
 	return c
+}
+
+//ModifyParts modifies parts
+func ModifyParts(p catalog.Part, controlParts []catalog.Part) []catalog.Part {
+
+	//append with all the parts
+	var parts []catalog.Part
+	for i, part := range controlParts {
+		if p.Class != part.Class {
+			parts = append(parts, part)
+			continue
+		}
+		id := part.Id
+		part.Id = fmt.Sprintf("%s_%d", id, i+1)
+		parts = append(parts, part)
+		part.Id = fmt.Sprintf("%s_%d", id, i+2)
+		parts = append(parts, part)
+	}
+	return parts
+}
+
+//FindAlter finds alter manipulation attribute in the profile import chain
+func FindAlter(call profile.Call, p *profile.Profile) (*profile.Alter, error) {
+
+	ec := make(chan error)
+	altCh := make(chan *profile.Alter)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	for _, i := range p.Imports {
+		go func(i profile.Import) {
+			traverseProfile(ctx, call, p, altCh, ec)
+		}(i)
+	}
+
+	select {
+	case alt := <-altCh:
+		return alt, nil
+	case err := <-ec:
+		return nil, err
+	case <-ctx.Done():
+		return nil, timeoutErr(call)
+	}
+
+}
+
+func traverseProfile(ctx context.Context, call profile.Call, p *profile.Profile, altCh chan *profile.Alter, errCh chan error) {
+
+	if p == nil {
+		errCh <- fmt.Errorf("profile cannot be nil")
+		return
+	}
+	if p.Modify == nil {
+		errCh <- fmt.Errorf("modify is nil")
+		return
+	}
+	for _, alt := range p.Modify.Alterations {
+		if alt.ControlId == call.ControlId {
+			altCh <- &alt
+			return
+		}
+		if alt.SubcontrolId == call.SubcontrolId {
+			altCh <- &alt
+			return
+		}
+	}
+
+	for _, imp := range p.Imports {
+		go func(imp profile.Import) {
+			if imp.Href == nil {
+				errCh <- fmt.Errorf("import href cannot be nil")
+				return
+			}
+			path, err := GetFilePath(imp.Href.String())
+			if err != nil {
+				errCh <- err
+				return
+			}
+			f, err := os.Open(path)
+			if err != nil {
+				errCh <- err
+				return
+			}
+			o, err := oscal.New(f)
+			if err != nil {
+				errCh <- err
+				return
+			}
+			if o.Profile == nil {
+				logrus.Warn("catalog found")
+				return
+			}
+			traverseProfile(ctx, call, o.Profile, altCh, errCh)
+		}(imp)
+
+	}
+
+}
+
+func timeoutErr(call profile.Call) error {
+	if call.ControlId != "" {
+		return fmt.Errorf("unable to find control id %s in the profile import chain, needs review", call.ControlId)
+	}
+	if call.SubcontrolId != "" {
+		return fmt.Errorf("unable to find sub-control id %s in the profile import chain, needs review", call.SubcontrolId)
+	}
+	return nil
 }

--- a/generator/manipulation.go
+++ b/generator/manipulation.go
@@ -1,0 +1,65 @@
+package generator
+
+import (
+	"fmt"
+
+	"github.com/docker/oscalkit/types/oscal/catalog"
+	"github.com/docker/oscalkit/types/oscal/profile"
+)
+
+func AddPartInCatalog(alterations []profile.Alter, c *catalog.Catalog) *catalog.Catalog {
+	for _, x := range alterations {
+		for i, g := range c.Groups {
+			for j, ctrl := range g.Controls {
+				if ctrl.Id == x.ControlId {
+					ctrlIncrement := 1
+					for _, add := range x.Additions {
+						for _, p := range add.Parts {
+							appended := false
+							for catalogCtrlPartIndex, catalogPart := range ctrl.Parts {
+								if p.Class == catalogPart.Class {
+									appended = true
+									ctrl.Parts[catalogCtrlPartIndex].Id = p.Id + fmt.Sprintf("_%d", ctrlIncrement)
+									ctrlIncrement++
+									p.Id = p.Id + fmt.Sprintf("_%d", ctrlIncrement)
+									position := (ctrlIncrement + catalogCtrlPartIndex) - 1
+									ctrl.Parts = append(ctrl.Parts[:position], append([]catalog.Part{p}, ctrl.Parts[position:]...)...)
+								}
+							}
+							if !appended {
+								ctrl.Parts = append(ctrl.Parts, p)
+							}
+						}
+					}
+					c.Groups[i].Controls[j] = ctrl
+				}
+				for k, subctrl := range c.Groups[i].Controls[j].Subcontrols {
+					subCtrlIncrement := 1
+					if subctrl.Id == x.SubcontrolId {
+						for _, add := range x.Additions {
+							for _, p := range add.Parts {
+								appended := false
+								for catalogSubCtrlPartIndex, catalogPart := range subctrl.Parts {
+									if p.Class == catalogPart.Class {
+										appended = true
+										subctrl.Parts[catalogSubCtrlPartIndex].Id = p.Id + fmt.Sprintf("_%d", subCtrlIncrement)
+										subCtrlIncrement++
+										position := (subCtrlIncrement + catalogSubCtrlPartIndex) - 1
+										subctrl.Parts = append(subctrl.Parts[:position], append([]catalog.Part{p}, subctrl.Parts[:position]...)...)
+									}
+								}
+								if !appended {
+									subctrl.Parts = append(subctrl.Parts, p)
+								}
+							}
+
+						}
+					}
+					c.Groups[i].Controls[j].Subcontrols[k] = subctrl
+
+				}
+			}
+		}
+	}
+	return c
+}

--- a/generator/manipulation.go
+++ b/generator/manipulation.go
@@ -13,7 +13,7 @@ import (
 	"github.com/docker/oscalkit/types/oscal/profile"
 )
 
-//ProcessAddition processess additions of a profile
+// ProcessAddition processes additions of a profile
 func ProcessAddition(alt profile.Alter, controls []catalog.Control) []catalog.Control {
 	for j, ctrl := range controls {
 		if ctrl.Id == alt.ControlId {
@@ -23,7 +23,7 @@ func ProcessAddition(alt profile.Alter, controls []catalog.Control) []catalog.Co
 					for _, catalogPart := range ctrl.Parts {
 						if p.Class == catalogPart.Class {
 							appended = true
-							//append with all the parts with matching classes
+							// append with all the parts with matching classes
 							parts := ModifyParts(p, ctrl.Parts)
 							ctrl.Parts = parts
 						}
@@ -43,7 +43,7 @@ func ProcessAddition(alt profile.Alter, controls []catalog.Control) []catalog.Co
 						for _, catalogPart := range subctrl.Parts {
 							if p.Class == catalogPart.Class {
 								appended = true
-								//append with all the parts
+								// append with all the parts
 								parts := ModifyParts(p, subctrl.Parts)
 								subctrl.Parts = parts
 							}
@@ -61,7 +61,7 @@ func ProcessAddition(alt profile.Alter, controls []catalog.Control) []catalog.Co
 	return controls
 }
 
-//ProcessAlteration processess alteration section of a profile
+// ProcessAlteration processes alteration section of a profile
 func ProcessAlteration(alterations []profile.Alter, c *catalog.Catalog) *catalog.Catalog {
 	for _, alt := range alterations {
 		for i, g := range c.Groups {
@@ -71,10 +71,10 @@ func ProcessAlteration(alterations []profile.Alter, c *catalog.Catalog) *catalog
 	return c
 }
 
-//ModifyParts modifies parts
+// ModifyParts modifies parts
 func ModifyParts(p catalog.Part, controlParts []catalog.Part) []catalog.Part {
 
-	//append with all the parts
+	// append with all the parts
 	var parts []catalog.Part
 	for i, part := range controlParts {
 		if p.Class != part.Class {
@@ -90,7 +90,7 @@ func ModifyParts(p catalog.Part, controlParts []catalog.Part) []catalog.Part {
 	return parts
 }
 
-//FindAlter finds alter manipulation attribute in the profile import chain
+// FindAlter finds alter manipulation attribute in the profile import chain
 func FindAlter(call profile.Call, p *profile.Profile) (*profile.Alter, error) {
 
 	ec := make(chan error)

--- a/generator/manipulation.go
+++ b/generator/manipulation.go
@@ -151,6 +151,7 @@ func traverseProfile(ctx context.Context, call profile.Call, p *profile.Profile,
 				errCh <- err
 				return
 			}
+			defer f.Close()
 			o, err := oscal.New(f)
 			if err != nil {
 				errCh <- err

--- a/generator/profile.go
+++ b/generator/profile.go
@@ -1,0 +1,34 @@
+package generator
+
+import (
+	"github.com/docker/oscalkit/types/oscal/profile"
+)
+
+//AppendAlterations appends alter attributes from import chain
+func AppendAlterations(p *profile.Profile) (*profile.Profile, error) {
+	if p.Modify == nil {
+		p.Modify = &profile.Modify{
+			Alterations:   []profile.Alter{},
+			ParamSettings: []profile.SetParam{},
+		}
+	}
+	for _, i := range p.Imports {
+		for _, call := range i.Include.IdSelectors {
+			alterFound := false
+			for _, alt := range p.Modify.Alterations {
+				if call.ControlId == alt.ControlId {
+					alterFound = true
+					break
+				}
+			}
+			if !alterFound {
+				alt, err := FindAlter(call, p)
+				if err != nil {
+					return nil, err
+				}
+				p.Modify.Alterations = append(p.Modify.Alterations, *alt)
+			}
+		}
+	}
+	return p, nil
+}

--- a/generator/profile.go
+++ b/generator/profile.go
@@ -4,7 +4,7 @@ import (
 	"github.com/docker/oscalkit/types/oscal/profile"
 )
 
-//AppendAlterations appends alter attributes from import chain
+// AppendAlterations appends alter attributes from import chain
 func AppendAlterations(p *profile.Profile) (*profile.Profile, error) {
 	if p.Modify == nil {
 		p.Modify = &profile.Modify{

--- a/generator/reader.go
+++ b/generator/reader.go
@@ -16,7 +16,7 @@ import (
 	"github.com/docker/oscalkit/types/oscal/profile"
 )
 
-//ReadCatalog ReadCatalog
+// ReadCatalog ReadCatalog
 func ReadCatalog(r io.Reader) (*catalog.Catalog, error) {
 
 	o, err := oscal.New(r)
@@ -32,7 +32,7 @@ func ReadCatalog(r io.Reader) (*catalog.Catalog, error) {
 
 }
 
-//ReadProfile reads profile from byte array
+// ReadProfile reads profile from byte array
 func ReadProfile(r io.Reader) (*profile.Profile, error) {
 
 	o, err := oscal.New(r)
@@ -45,7 +45,7 @@ func ReadProfile(r io.Reader) (*profile.Profile, error) {
 	return o.Profile, nil
 }
 
-//GetFilePath GetFilePath
+// GetFilePath GetFilePath
 func GetFilePath(URL string) (string, error) {
 	uri, err := url.Parse(URL)
 	if err != nil {
@@ -74,7 +74,7 @@ func GetFilePath(URL string) (string, error) {
 
 }
 
-//GetAbsolutePath gets absolute file path
+// GetAbsolutePath gets absolute file path
 func GetAbsolutePath(path string) (string, error) {
 	if filepath.IsAbs(path) {
 		return path, nil

--- a/templates/catalog.go
+++ b/templates/catalog.go
@@ -34,6 +34,7 @@ var ApplicableControls = []catalog.Catalog{
 										catalog.Part{
 											Id:  "{{.Id}}",
 											Class: "{{.Class}}",
+											Title: "{{.Title}}",
 											},
 									{{end}}
 								},

--- a/templates/catalog.go
+++ b/templates/catalog.go
@@ -29,12 +29,28 @@ var ApplicableControls = []catalog.Catalog{
 								Id: 	"{{.Id}}",
 								Class: 	"{{.Class}}",
 								Title:	"{{.Title}}",
+								Parts:  []catalog.Part{
+									{{range .Parts}}
+										catalog.Part{
+											Id:  "{{.Id}}",
+											Class: "{{.Class}}",
+											},
+									{{end}}
+								},
 								Subcontrols: []catalog.Subcontrol{
 									{{range .Subcontrols}}
 									{
 										Id: 	"{{.Id}}",
 										Class: 	"{{.Class}}",
 										Title:	"{{.Title}}",		
+										Parts:  []catalog.Part{
+											{{range .Parts}}
+												catalog.Part{
+													Id:  "{{.Id}}",
+													Class: "{{.Class}}",
+													},
+											{{end}}
+										},
 									},
 									{{end}}
 								},


### PR DESCRIPTION
# Description

Attempts to process `manipulation` attributes in the profile `modify` section.
Linking to #12.
 
## Feature set
1. Concurrent `import` chain traversal is enabled to fetch the root catalog for each import
2. Recursively searches the `import` chain for the controls/subcontrols referenced by the root profile for `add` manipulation attribute
3. Appends `part`s with the same `class` instead of adding a new `part`

