### PR TITLE
Import path

### DIFF
--- a/cli/cmd/generate/code.go
+++ b/cli/cmd/generate/code.go
@@ -78,6 +78,10 @@ var Code = cli.Command{
 		}
 		defer newFile.Close()
 
+		profile, err = generator.SetBasePath(profile, profilePath)
+		if err != nil {
+			cli.NewExitError(fmt.Errorf("failed to setup href path for profiles: %v", err), 1)
+		}
 		catalogs, err := generator.CreateCatalogsFromProfile(profile)
 		if err != nil {
 			return cli.NewExitError(fmt.Sprintf("cannot create catalogs from profile, err: %v", err), 1)

--- a/generator/profile.go
+++ b/generator/profile.go
@@ -1,6 +1,13 @@
 package generator
 
 import (
+	"fmt"
+	"net/url"
+	"path"
+	"path/filepath"
+
+	"github.com/docker/oscalkit/types/oscal/catalog"
+
 	"github.com/docker/oscalkit/types/oscal/profile"
 )
 
@@ -29,6 +36,28 @@ func AppendAlterations(p *profile.Profile) (*profile.Profile, error) {
 				p.Modify.Alterations = append(p.Modify.Alterations, *alt)
 			}
 		}
+	}
+	return p, nil
+}
+
+//SetBasePath sets up base paths for profiles
+func SetBasePath(p *profile.Profile, parentPath string) (*profile.Profile, error) {
+
+	for i, x := range p.Imports {
+
+		if x.Href == nil {
+			return nil, fmt.Errorf("href cannot be nil")
+		}
+		path := fmt.Sprintf("%s/%s", path.Dir(parentPath), path.Base(x.Href.String()))
+		path, err := filepath.Abs(path)
+		if err != nil {
+			return nil, err
+		}
+		uri, err := url.Parse(path)
+		if err != nil {
+			return nil, err
+		}
+		p.Imports[i].Href = &catalog.Href{URL: uri}
 	}
 	return p, nil
 }

--- a/generator/validator.go
+++ b/generator/validator.go
@@ -1,0 +1,20 @@
+package generator
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/docker/oscalkit/types/oscal/catalog"
+)
+
+func ValidateHref(href *catalog.Href) error {
+	if href == nil {
+		return fmt.Errorf("Href cannot be empty")
+	}
+
+	_, err := url.Parse(href.String())
+	if err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
# Description
Addresses https://github.com/docker/oscalkit/issues/57 
In a scenario where `oscalkit generate -p /someDir/profile.xml` is run, and `profile.xml` has a relative import like `../catalog.xml`, then the directory that will  be searched is `/someDir`