### PR TITLE
remove redundant code from templates

### DIFF
--- a/templates/catalog.go
+++ b/templates/catalog.go
@@ -17,21 +17,21 @@ import (
 
 var ApplicableControls = []catalog.Catalog{
 {{range .Catalogs}}
-	catalog.Catalog{
+	{
 		Title: "{{ .Title }}",
 		Groups: []catalog.Group{
 			{{range .Groups}}
-				catalog.Group{
+				{
 					Id:  "{{.Title}}",
 					Controls: []catalog.Control{
 						{{range .Controls}}
-							catalog.Control{
+							{
 								Id: 	"{{.Id}}",
 								Class: 	"{{.Class}}",
 								Title:	"{{.Title}}",
 								Subcontrols: []catalog.Subcontrol{
 									{{range .Subcontrols}}
-									catalog.Subcontrol{
+									{
 										Id: 	"{{.Id}}",
 										Class: 	"{{.Class}}",
 										Title:	"{{.Title}}",		

--- a/templates/implementation.go
+++ b/templates/implementation.go
@@ -22,7 +22,7 @@ var ImplementationGenerated = implementation.Implementation{
 		implementation.ComponentDefinition{
 			ComponentConfigurations: []*implementation.ComponentConfiguration{
 					{{range .ComponentConfigurations}}
-					&implementation.ComponentConfiguration{
+					{
 							ID:                     ` + "`{{.ID}}`" + `,
 							Name:                   ` + "`{{.Name}}`" + `,
 							Description:            ` + "`{{.Description}}`" + `,
@@ -30,7 +30,7 @@ var ImplementationGenerated = implementation.Implementation{
 							ValidationMechanisms:   []implementation.Mechanism{},
 							ConfigurableValues: []implementation.ConfigurableValue{
 								{{range .ConfigurableValues}}
-									implementation.ConfigurableValue{
+									{
 											Value:   "{{.Value}}",
 											ValueID: "{{.ValueID}}",
 									},
@@ -41,15 +41,15 @@ var ImplementationGenerated = implementation.Implementation{
 				},
 				ImplementsProfiles: []*implementation.ImplementsProfile{
 					{{range .ImplementsProfiles}}
-						&implementation.ImplementsProfile{
+						{
 							ProfileID: "{{.ProfileID}}",
 							ControlConfigurations: []implementation.ControlConfiguration{
 								{{range .ControlConfigurations}}
-									implementation.ControlConfiguration{
+									{
 										ConfigurationIDRef: "{{.ConfigurationIDRef}}",
 										Parameters:         []implementation.Parameter{
 											{{range .Parameters}}
-											implementation.Parameter{
+											{
 												Guidance: "{{.Guidance}}",
 												ParameterID: "{{.ParameterID}}",
 												ValueID: "{{.ValueID}}",
@@ -69,11 +69,11 @@ var ImplementationGenerated = implementation.Implementation{
 				},
 				ControlImplementations: []*implementation.ControlImplementation{
 					{{range .ControlImplementations}}
-						&implementation.ControlImplementation{
+						{
 							ID: "{{.ID}}",
 							ControlIds: []implementation.ControlId{
 								{{range .ControlIds}}
-								implementation.ControlId{
+								{
 										CatalogIDRef: "{{.CatalogIDRef}}",
 										ControlID:	 ` + "`{{.ControlID}}`" + `,
 										ItemID: 	 ` + "`{{.ItemID}}`" + `,
@@ -82,14 +82,14 @@ var ImplementationGenerated = implementation.Implementation{
 							},
 							ControlConfigurations: []implementation.ControlConfiguration{
 								{{range .ControlConfigurations}}
-									implementation.ControlConfiguration{
+									{
 										ConfigurationIDRef: "{{.ConfigurationIDRef}}",
 										ProvisioningMechanisms: []implementation.ProvisioningMechanism{
 											{{range .ProvisioningMechanisms}}
-												implementation.ProvisioningMechanism{
+												{
 													ProvisionedControls: []implementation.ControlId{
 														{{range .ProvisionedControls}}
-															implementation.ControlId{
+															{
 																ControlID:    "{{.ControlID}}",
 																CatalogIDRef: "{{.CatalogIDRef}}",
 																ItemID:       "{{.ItemID}}",
@@ -102,7 +102,7 @@ var ImplementationGenerated = implementation.Implementation{
 										},
 										Parameters:         []implementation.Parameter{
 											{{range .Parameters}}
-											implementation.Parameter{
+											{
 												Guidance: "{{.Guidance}}",
 												ParameterID: "{{.ParameterID}}",
 												ValueID: "{{.ValueID}}",

--- a/templates/profile.go
+++ b/templates/profile.go
@@ -25,7 +25,7 @@ import (
 
 var ApplicableProfileControls = profile.Profile{
 	Imports: []profile.Import{
-		profile.Import{
+		{
 			{{range .Profile.Imports}}
 				Exclude: &profile.Exclude{
 					IdSelectors: []profile.Call{
@@ -34,7 +34,7 @@ var ApplicableProfileControls = profile.Profile{
 				Include: &profile.Include{
 					IdSelectors: []profile.Call{
 						{{range .Include.IdSelectors}}
-							profile.Call{
+							{
 									ControlId: "{{.ControlId}}",
 									SubcontrolId: "{{.SubcontrolId}}",
 							},
@@ -56,16 +56,16 @@ var ApplicableProfileControls = profile.Profile{
 	Modify: &profile.Modify{
 		Alterations: []profile.Alter{
 			{{range .Profile.Modify.Alterations}}
-				profile.Alter{
+				{
 					ControlId: "123",
 					Additions: []profile.Add{
 						{{range .Additions}}
-							profile.Add{
+							{
 								Title: "{{.Title}}",
 								Position: "{{.Position}}",
 								Props: []catalog.Prop{
 									{{range .Props}}
-										catalog.Prop{
+										{
 											Class: "{{.Class}}",
 											Id:    "{{.Id}}",
 											Value: "{{.Value}}",


### PR DESCRIPTION
# Description

This PR removes the redundant code from templates which generate controls, implementation. The orca CI formatter lint checks fail and ask to format the generated files using `$ gofmt -s`.