### PR TITLE
Add sub commands for generate cmd

### DIFF
--- a/cli/cmd/cmd.go
+++ b/cli/cmd/cmd.go
@@ -15,6 +15,7 @@ import (
 	"os"
 
 	"github.com/docker/oscalkit/cli/cmd/convert"
+	"github.com/docker/oscalkit/cli/cmd/generate"
 	"github.com/docker/oscalkit/cli/version"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
@@ -49,8 +50,7 @@ func Execute() error {
 		convert.Convert,
 		Validate,
 		Sign,
-		Generate,
-		Implementation,
+		generate.Generate,
 	}
 
 	return app.Run(os.Args)

--- a/cli/cmd/generate/catalog.go
+++ b/cli/cmd/generate/catalog.go
@@ -1,0 +1,92 @@
+package generate
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/docker/oscalkit/generator"
+	"github.com/urfave/cli"
+)
+
+var isJSON bool
+
+// Catalog generates json/xml catalogs
+var Catalog = cli.Command{
+	Name:  "catalogs",
+	Usage: "generates json/xml catalogs provided profile",
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:        "profile, p",
+			Usage:       "profile to intersect against",
+			Destination: &profilePath,
+		},
+		cli.StringFlag{
+			Name:        "output, o",
+			Usage:       "output filename",
+			Destination: &outputFileName,
+			Value:       "output",
+		},
+		cli.BoolFlag{
+
+			Name:        "json, j",
+			Usage:       "flag for generating catalogs in json",
+			Destination: &isJSON,
+		},
+	},
+	Before: func(c *cli.Context) error {
+		if profilePath == "" {
+			return cli.NewExitError("oscalkit generate is missing the --profile flag", 1)
+		}
+		return nil
+	},
+	Action: func(c *cli.Context) error {
+
+		profilePath, err := generator.GetAbsolutePath(profilePath)
+		if err != nil {
+			return cli.NewExitError(fmt.Sprintf("cannot get absolute path, err: %v", err), 1)
+		}
+
+		_, err = os.Stat(profilePath)
+		if err != nil {
+			return cli.NewExitError(fmt.Sprintf("cannot fetch file, err %v", err), 1)
+		}
+		f, err := os.Open(profilePath)
+		if err != nil {
+			return cli.NewExitError(err, 1)
+		}
+		defer f.Close()
+
+		profile, err := generator.ReadProfile(f)
+		if err != nil {
+			return cli.NewExitError(err, 1)
+		}
+		catalogs, err := generator.CreateCatalogsFromProfile(profile)
+		if err != nil {
+			return cli.NewExitError(fmt.Sprintf("cannot create catalogs from profile, err: %v", err), 1)
+		}
+
+		var bytes []byte
+		if !isJSON {
+			bytes, err = xml.MarshalIndent(catalogs, "", "  ")
+			if err != nil {
+				return err
+			}
+			return ioutil.WriteFile(outputFileName+".xml", bytes, 0644)
+		}
+		bytes, err = json.MarshalIndent(catalogs, "", "  ")
+		if err != nil {
+			return err
+		}
+		return ioutil.WriteFile(outputFileName+".json", bytes, 0644)
+
+	},
+	After: func(c *cli.Context) error {
+		logrus.Info("catalog file generated")
+		return nil
+	},
+}

--- a/cli/cmd/generate/code.go
+++ b/cli/cmd/generate/code.go
@@ -1,4 +1,4 @@
-package cmd
+package generate
 
 import (
 	"fmt"
@@ -18,9 +18,9 @@ var profilePath string
 var outputFileName string
 var packageName string
 
-//Generate Cli command to generate go code for controls
-var Generate = cli.Command{
-	Name:  "generate",
+// Code Cli command to generate go code for controls in catalog
+var Code = cli.Command{
+	Name:  "code",
 	Usage: "generates go code against provided profile",
 	Flags: []cli.Flag{
 		cli.StringFlag{

--- a/cli/cmd/generate/generate.go
+++ b/cli/cmd/generate/generate.go
@@ -1,0 +1,16 @@
+package generate
+
+import (
+	"github.com/urfave/cli"
+)
+
+// Generate Cli command to generate go code for controls
+var Generate = cli.Command{
+	Name:  "generate",
+	Usage: "generates catalogs code/xml/json against provided profile",
+	Subcommands: []cli.Command{
+		Catalog,
+		Code,
+		Implementation,
+	},
+}

--- a/cli/cmd/generate/implementation.go
+++ b/cli/cmd/generate/implementation.go
@@ -1,4 +1,4 @@
-package cmd
+package generate
 
 import (
 	"bytes"


### PR DESCRIPTION
# Description
Adds subcommands to the parent `generate` command; enabling json/xml catalogs and, go catalogs and `Prose` parsing yet to be developed.

# Links
Partially addressess issue https://github.com/docker/oscalkit/issues/61. `catalog.Prose` parsing is yet to be addressed