### PR TITLE
remove redundant template

### DIFF
--- a/templates/implementation.go
+++ b/templates/implementation.go
@@ -25,7 +25,7 @@ var ImplementationGenerated = implementation.Implementation{
 	Capabilities: implementation.Capabilities{},
 	ComponentDefinitions: []implementation.ComponentDefinition{
 		{{range .Implementation.ComponentDefinitions}}
-		implementation.ComponentDefinition{
+		{
 			ID: ` + "`{{.ID}}`" + `,
 			ComponentConfigurations: []*implementation.ComponentConfiguration{
 					{{range .ComponentConfigurations}}


### PR DESCRIPTION
Removing this to make sure the CI does not fail for docker/orca whenever an implementation is generated.